### PR TITLE
Fixed test crashing

### DIFF
--- a/emantomo/tests/test_eman_sta_classic_base.py
+++ b/emantomo/tests/test_eman_sta_classic_base.py
@@ -39,7 +39,6 @@ from pyworkflow.tests import BaseTest, DataSet, setupTestProject
 from pyworkflow.utils import magentaStr
 from tomo.objects import SetOfSubTomograms
 from tomo.protocols import ProtImportTomograms, ProtImportCoordinates3DFromScipion
-from tomo.protocols.protocol_import_coordinates_from_scipion import outputObjs
 from tomo.tests import EMD_10439, DataSetEmd10439
 
 
@@ -113,7 +112,7 @@ class TestEmantomoStaClassicBase(BaseTest):
                                                   boxSize=cls.boxSize)
 
         cls.launchProtocol(protImportCoordinates3d)
-        coordsImported = getattr(protImportCoordinates3d, outputObjs.coordinates.name, None)
+        coordsImported = getattr(protImportCoordinates3d, "outputCoordinates", None)
         cls.assertIsNotNone(coordsImported, "There was a problem with the 3D coordinates output")
         return coordsImported
 


### PR DESCRIPTION
line 42 was causing error:
Traceback (most recent call last):
  File "/home/martin/Documentos/miniconda/envs/scipion3/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/home/martin/Documentos/miniconda/envs/scipion3/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/home/martin/Documentos/miniconda/envs/scipion3/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/home/martin/Documentos/miniconda/envs/scipion3/lib/python3.8/unittest/loader.py", line 34, in testFailure
    raise self._exception
ImportError: Failed to import test module: test_protocols_sta_classic_workflow Traceback (most recent call last):
  File "/home/martin/Documentos/miniconda/envs/scipion3/lib/python3.8/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/home/martin/Documentos/standalone-installations/plugins/scipion-em-emantomo/emantomo/tests/test_protocols_sta_classic_workflow.py", line 30, in <module>
    from .test_eman_sta_classic_base import TestEmantomoStaClassicBase
  File "/home/martin/Documentos/standalone-installations/plugins/scipion-em-emantomo/emantomo/tests/test_eman_sta_classic_base.py", line 42, in <module>
    from tomo.protocols.protocol_import_coordinates_from_scipion import outputObjs
ImportError: cannot import name 'outputObjs' from 'tomo.protocols.protocol_import_coordinates_from_scipion' (/home/martin/Documentos/standalone-installations/plugins/scipion-em-tomo/tomo/protocols/protocol_import_coordinates_from_scipion.py)

I guess the output object from protocol_import_coordinates_from_scipion is named outputCoordinates, so that's the name of the attribute to look for, although it cannot be imported, but it can be obtained with the getattr function if the atrribute name is introduced as a string. With this change I ran command "scipion3 tests emantomo.tests.test_protocols_sta_classic_workflow" and everything seemed to work properly.