### PR TITLE
Update the acquisition order in the CTFTomo objects

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+v3.3.2:
+ Developers:
+  - Update the acquisition order in the CTFTomo objects (field added to that class in scipion-em-tomo v3.7.0).
 v3.3.1:
  Users:
   - Small fixes regarding the register of the tilt series acquisition attributes.

--- a/emantomo/__init__.py
+++ b/emantomo/__init__.py
@@ -22,7 +22,7 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
-__version__ = "3.3.1"
+__version__ = "3.3.2"
 _logo = "eman2_logo.png"
 _references = ['GALAZMONTOYA2015279', 'BELL201625']
 _url = "https://github.com/scipion-em/scipion-em-emantomo"

--- a/emantomo/protocols/protocol_estimate_ctf.py
+++ b/emantomo/protocols/protocol_estimate_ctf.py
@@ -151,6 +151,7 @@ class EmanProtEstimateCTF(ProtEmantomoBase):
                 defocusU = defocusV = 10000.0 * defocus[idx]
                 newCTFTomo = CTFTomo()
                 newCTFTomo.setIndex(idx + 1)
+                newCTFTomo.setAcquisitionOrder(tiltImage.getAcquisitionOrder())
                 if phase_shift[idx] != 0:
                     newCTFTomo.setPhaseShift(phase_shift[idx])
                 newCTFTomo.setDefocusU(defocusU)

--- a/emantomo/tests/test_protocols_sta_pppt.py
+++ b/emantomo/tests/test_protocols_sta_pppt.py
@@ -197,7 +197,7 @@ class TestEmanEstimateCtf(TestEmanBasePPPT):
         outCtfs = getattr(protEstimateCtf, protEstimateCtf._possibleOutputs.CTFs.name, None)
         self.assertIsNotNone(outCtfs, "There was a problem estimating the CTFs")
         # Check the CTFs
-        self.checkCTFs(outCtfs, expectedSetSize=1)
+        self.checkCTFs(outCtfs, expectedSetSize=len(self.importedTs))
 
 
 class TestBaseRefineCyclePPPT(TestEmanBasePPPT):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 scipion-em>=3.5.0
 scipion-em-eman2
-scipion-em-tomo>=3.6.1
+scipion-em-tomo>=3.7.0
 h5py==3.8.0


### PR DESCRIPTION
In scipion-em-tomo version 3.7.0, the acquisition order has been added to the CTFTomo to provide a robust field to match between tilt-images and CTFTomo when they come from different places, such as in Reliontomo prepare or IMOD ctf correction. It opens a way to robustly deal with re-stacked files, excluded vies, etc.